### PR TITLE
MNT: Do not require owner, group, beamlin_id at the schema level.

### DIFF
--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -35,10 +35,7 @@
     },
     "required": [
         "uid",
-        "time",
-        "group",
-        "owner",
-        "beamline_id"
+        "time"
      ],
     "type": "object",
     "description": "Document created at the start of run.  Provides a seach target and later documents link to it"

--- a/event_model/schemas/run_start.json
+++ b/event_model/schemas/run_start.json
@@ -8,10 +8,6 @@
             "type": ["object", "string"],
             "description": "Information about the sample, may be a UID to another collection"
         },
-        "beamline_id": {
-            "type": "string",
-            "description": "The beamline ID"
-        },
         "scan_id": {
             "type": "integer",
             "description": "Scan ID number, not globally unique"


### PR DESCRIPTION
As previously discussed:

* None of these required fields as being used or even defined in a uniform way.
* The set of required fields can and should be customized on a beamline by beamline level.
* The requirement that owner, group, project at least be *strings* is still maintained in the schema, which helps support the possibility of multi-beamline search queries in the future -- it's not the wild west. ;- )
* Just a reminder: it is still possible to index a non-required field without a special index, so long as that field is non-unique. That is the case here.

A bluesky PR is ready -- will push as soon as this is merged so that the tests pass.