### PR TITLE
API: allow 'filled' property in events in bulk_events

### DIFF
--- a/event_model/schemas/bulk_events.json
+++ b/event_model/schemas/bulk_events.json
@@ -14,6 +14,10 @@
                         "type": "object",
                         "description": "The timestamps of the individual measument data"
                     },
+		    "filled": {
+			"type": "object",
+			"description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
+		    },
                     "descriptor": {
                         "type": "string",
                         "description": "UID to point back to Descriptor for this event stream"


### PR DESCRIPTION
This is required to implement fix for https://github.com/NSLS-II/bluesky/issues/661

'filled' is already an optional field on normal events.