### PR TITLE
Add 'num_events' field to RunStop schema.

### DIFF
--- a/event_model/schemas/run_stop.json
+++ b/event_model/schemas/run_stop.json
@@ -27,6 +27,12 @@
         "uid": {
             "type": "string",
             "description": "Globally unique ID for tihs run"
+        },
+        "num_events": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": { "type": "integer" },
+            "description": "Number of Events per named stream"
         }
     },
     "patternProperties": {


### PR DESCRIPTION
Related to https://github.com/NSLS-II/bluesky/pull/852

This adds:

* a description of the meaning of the field
* a restriction that its value must be an integer

I ran the bluesky tests against this branch and they passed.
I also tried inserting a document with an illegal (non-integer) value
(by editing run_engine.py) the validator correctly objected.