### PR TITLE
MNT: If an EventDescriptor has a 'name' it should be a string.

### DIFF
--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -87,6 +87,10 @@
             },
             "hints": {
                 "$ref": "#/definitions/object_hints"
+            },
+            "name": {
+                "type": "string",
+                "description": "A human-friendly name for this data stream, such as 'primary' or 'baseline'."
             }
         },
         "patternProperties": {


### PR DESCRIPTION
The 'name' field in EventDescriptors was introduced late and has always been
optional. This change leaves it optional, but requires that if the 'name' field
is present, that it is a string. We make this assumption in a couple places
downstream so it would be good to enforce it here.