### PR TITLE
Typo-fix

### DIFF
--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -41,4 +41,4 @@
     "type": "object",
     "title": "event",
     "description": "Document to record a quanta of collected data"
-}:
+}

--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -2,11 +2,11 @@
     "properties": {
         "data": {
             "type": "object",
-            "description": "The actual measument data"
+            "description": "The actual measurement data"
         },
         "timestamps": {
             "type": "object",
-            "description": "The timestamps of the individual measument data"
+            "description": "The timestamps of the individual measurement data"
         },
         "filled": {
             "type": "object",
@@ -41,4 +41,4 @@
     "type": "object",
     "title": "event",
     "description": "Document to record a quanta of collected data"
-}
+}:


### PR DESCRIPTION
FIX: Measurement was spelled measument.