### PR TITLE
ENH: Add document-composing tools.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1,9 +1,15 @@
 import json
+import jsonschema
 from enum import Enum
+from functools import partial
+import itertools
+import os
 from pkg_resources import resource_filename as rs_fn
+import time as ttime
+import uuid
 from ._version import get_versions
 
-__all__ = ['DocumentNames', 'schemas']
+__all__ = ['DocumentNames', 'schemas', 'create_run']
 
 
 class DocumentNames(Enum):
@@ -14,6 +20,14 @@ class DocumentNames(Enum):
     bulk_events = 'bulk_events'
     datum = 'datum'
     resource = 'resource'
+
+
+class EventModelError(Exception):
+    ...
+
+
+class EventModelValidationError(EventModelError):
+    ...
 
 
 SCHEMA_PATH = 'schemas'
@@ -31,3 +45,157 @@ for name, filename in SCHEMA_NAMES.items():
 
 __version__ = get_versions()['version']
 del get_versions
+
+
+def create_datum(*, resource, counter, datum_kwargs, validate=True):
+    resource_uid = resource['uid']
+    doc = {'resource': resource_uid,
+           'datum_kwargs': datum_kwargs,
+           'datum_id': '{}/{}'.format(resource_uid, next(counter))}
+    if validate:
+        jsonschema.validate(DocumentNames.datum, doc)
+    return doc
+
+
+def create_resource(*, start, spec, root, resource_path, resource_kwargs,
+                    path_semantics=os.name, uid=None, validate=True):
+    if uid is None:
+        uid = str(uuid.uuid4())
+    counter = itertools.count()
+    doc = {'uid': uid,
+           'run_start': start['uid'],
+           'spec': spec,
+           'root': root,
+           'resource_path': resource_path,
+           'resource_kwargs': {},
+           'path_semantics': path_semantics}
+    if validate:
+        jsonschema.validate(DocumentNames.resource, doc)
+    return (doc,
+            partial(create_datum, resource=doc, counter=counter))
+
+
+def create_stop(*, start, event_counter, poison_pill,
+                exit_status='success', reason='',
+                uid=None, time=None,
+                validate=True):
+    if poison_pill:
+        raise EventModelError("Already created a RunStop document for run "
+                              "{!r}.".format(start['uid']))
+    poison_pill.append(object())
+    if uid is None:
+        uid = str(uuid.uuid4())
+    if time is None:
+        time = ttime.time()
+    doc = {'uid': uid,
+           'time': time,
+           'run_start': start['uid'],
+           'exit_status': exit_status,
+           'reason': reason,
+           'num_events': dict(event_counter)}
+    if validate:
+        jsonschema.validate(DocumentNames.stop, doc)
+    return doc
+
+
+def create_event(*, descriptor, event_counter, data, timestamps, seq_num,
+                 filled=None, uid=None, time=None, validate=True):
+    if uid is None:
+        uid = str(uuid.uuid4())
+    if time is None:
+        time = ttime.time()
+    if filled is None:
+        filled = {}
+    doc = {'uid': uid,
+           'time': time,
+           'data': data,
+           'timestamps': timestamps,
+           'seq_num': seq_num,
+           'filled': filled}
+    if validate:
+        jsonschema.validate(DocumentNames.event, doc)
+        if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
+            raise EventModelValidationError(
+                "These sets of keys must match:\n"
+                "event['data'].keys(): {}\n"
+                "event['timestamps'].keys(): {}\n"
+                "descriptor['data_keys'].keys(): {}\n".format(
+                    data.keys(), timestamps.keys(), descriptor['data_keys'].keys()))
+        if set(filled) - set(data):
+            raise EventModelValidationError(
+                "Keys in event['filled'] {} must be a subset of those in "
+                "event['data'] {}".format(filled.keys(), data.keys()))
+    event_counter[descriptor['name']] += 1
+    return doc
+
+
+def create_descriptor(*, start, streams, event_counter,
+                      name, data_keys, uid=None, time=None,
+                      object_names=None, configuration=None, hints=None,
+                      validate=True):
+    if uid is None:
+        uid = str(uuid.uuid4())
+    if time is None:
+        time = ttime.time()
+    if object_names is None:
+        object_names = {}
+    if configuration is None:
+        configuration = {}
+    if hints is None:
+        hints = {}
+    doc = {'uid': uid,
+           'time': time,
+           'run_start': start['uid'],
+           'name': name,
+           'data_keys': data_keys,
+           'object_names': object_names,
+           'hints': hints,
+           'configuration': configuration}
+    if validate:
+        jsonschema.validate(DocumentNames.descriptor, doc)
+        if name in streams and streams[name] != set(data_keys):
+            raise EventModelValidationError(
+                "A descriptor with the name {} has already been created with "
+                "data_keys {}. The requested data_keys were {}. All "
+                "descriptors in a given stream must have the same "
+                "data_keys.".format(name, streams[name], set(data_keys)))
+    if name not in streams:
+        streams[name] = set(data_keys)
+        event_counter[name] = 0
+    return (doc,
+            partial(create_event, descriptor=doc, event_counter=event_counter))
+
+
+def create_run(*, uid=None, time=None, metadata=None, validate=True):
+    """
+    Create a RunStart document and factory functions for related documents.
+    uid : string, optional
+        Unique identifier for this run, conventionally a UUID4. If None is
+        given, a UUID4 will be generated.
+    time: float, optional
+        UNIX epoch time of start of this run. If None is given, the current
+        time will be used.
+    metadata : dict, optional
+        Additional metadata include the document
+    validate : boolean, optional
+        Validate this document conforms to the schema.
+    """
+    if uid is None:
+        uid = str(uuid.uuid4())
+    if time is None:
+        time = ttime.time()
+    if metadata is None:
+        metadata = {}
+    doc = dict(uid=uid, time=time, **metadata)
+    # Define some mutable state to be shared internally by the closures created
+    # below.
+    streams = {}
+    event_counter = {}
+    poison_pill = []
+    if validate:
+        jsonschema.validate(DocumentNames.start, doc)
+    return (doc,
+            partial(create_descriptor, start=doc, streams=streams, event_counter={}),
+            partial(create_resource, start=doc),
+            partial(create_stop, start=doc, event_counter=event_counter,
+                    poison_pill=poison_pill))

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -48,12 +48,12 @@ __version__ = get_versions()['version']
 del get_versions
 
 ComposeRunBundle = namedtuple('ComposeRunBundle',
-                             'start_doc compose_descriptor compose_resource compose_stop')
+                              'start_doc compose_descriptor compose_resource '
+                              'compose_stop')
 ComposeDescriptorBundle = namedtuple('ComposeDescriptorBundle',
-                                    'descriptor_doc compose_event')
+                                     'descriptor_doc compose_event')
 ComposeResourceBundle = namedtuple('ComposeResourceBundle',
-                                  'resource_doc compose_datum')
-
+                                   'resource_doc compose_datum')
 
 
 def compose_datum(*, resource, counter, datum_kwargs, validate=True):
@@ -67,7 +67,7 @@ def compose_datum(*, resource, counter, datum_kwargs, validate=True):
 
 
 def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
-                    path_semantics=os.name, uid=None, validate=True):
+                     path_semantics=os.name, uid=None, validate=True):
     if uid is None:
         uid = str(uuid.uuid4())
     counter = itertools.count()
@@ -86,9 +86,9 @@ def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
 
 
 def compose_stop(*, start, event_counter, poison_pill,
-                exit_status='success', reason='',
-                uid=None, time=None,
-                validate=True):
+                 exit_status='success', reason='',
+                 uid=None, time=None,
+                 validate=True):
     if poison_pill:
         raise EventModelError("Already composed a RunStop document for run "
                               "{!r}.".format(start['uid']))
@@ -109,7 +109,7 @@ def compose_stop(*, start, event_counter, poison_pill,
 
 
 def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
-                 filled=None, uid=None, time=None, validate=True):
+                  filled=None, uid=None, time=None, validate=True):
     if uid is None:
         uid = str(uuid.uuid4())
     if time is None:
@@ -140,9 +140,9 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
 
 
 def compose_descriptor(*, start, streams, event_counter,
-                      name, data_keys, uid=None, time=None,
-                      object_names=None, configuration=None, hints=None,
-                      validate=True):
+                       name, data_keys, uid=None, time=None,
+                       object_names=None, configuration=None, hints=None,
+                       validate=True):
     if uid is None:
         uid = str(uuid.uuid4())
     if time is None:

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -17,3 +17,34 @@ def test_schemas():
     for k in event_model.DocumentNames:
         assert k in event_model.SCHEMA_NAMES
         assert event_model.schemas[k]
+
+
+def test_compose_run():
+    # Compose each kind of document type. These calls will trigger
+    # jsonschema.validate and ensure that the document-generation code composes
+    # valid documents.
+    bundle = event_model.compose_run()
+    start_doc, compose_descriptor, compose_resource, compose_stop = bundle
+    assert bundle.start_doc is start_doc
+    assert bundle.compose_descriptor is compose_descriptor
+    assert bundle.compose_resource is compose_resource
+    assert bundle.compose_stop is compose_stop
+    bundle = compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number'},
+                   'image': {'shape': [512, 512], 'dtype': 'number',
+                             'external': 'FILESTORE:'}},
+        name='primary')
+    descriptor_doc, compose_event = bundle
+    assert bundle.descriptor_doc is descriptor_doc
+    assert bundle.compose_event is compose_event
+    bundle = compose_resource(
+    spec='TIFF', root='/tmp', resource_path='stack.tiff', resource_kwargs={})                                                                        
+    resource_doc, compose_datum = bundle
+    assert bundle.resource_doc is resource_doc
+    assert bundle.compose_datum is compose_datum
+    datum_doc = compose_datum(datum_kwargs={'slice': 5})
+    event_doc = compose_event(
+        data={'motor': 0, 'image': datum_doc['datum_id']},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
+        seq_num=1)                                          
+    stop_doc = compose_stop()

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -38,13 +38,14 @@ def test_compose_run():
     assert bundle.descriptor_doc is descriptor_doc
     assert bundle.compose_event is compose_event
     bundle = compose_resource(
-    spec='TIFF', root='/tmp', resource_path='stack.tiff', resource_kwargs={})                                                                        
+        spec='TIFF', root='/tmp', resource_path='stack.tiff',
+        resource_kwargs={})
     resource_doc, compose_datum = bundle
     assert bundle.resource_doc is resource_doc
     assert bundle.compose_datum is compose_datum
     datum_doc = compose_datum(datum_kwargs={'slice': 5})
-    event_doc = compose_event(
+    compose_event(
         data={'motor': 0, 'image': datum_doc['datum_id']},
         timestamps={'motor': 0, 'image': 0}, filled={'image': False},
-        seq_num=1)                                          
-    stop_doc = compose_stop()
+        seq_num=1)
+    compose_stop()

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(name='event_model',
       version=versioneer.get_version(),
       cmdclass=versioneer.get_cmdclass(),
       package_data={'event_model': ['schemas/*.json']},
+      install_requires=['jsonschema'],
       include_package_data=True)


### PR DESCRIPTION
The only public function is ``create_run``. It returns closures over other
functions, passing internal shared state to manage foreign keys, counters,
and some inter-document validation.

Submitted for early review. Do not merge.

Example usage:

```
import event_model                                                                                                                                                                            
start_doc, create_descriptor, create_resource, create_stop = event_model.create_run()                                                                                                         
print(start_doc)                                                                                                                                                                              
descriptor_doc, create_event = create_descriptor(data_keys={'motor': {'shape': [], 'dtype': 'number'}, 'image': {'shape': [512, 512], 'dtype': 'number', 'external': 'FILESTORE:'}}, name='pri
mary')                                                                                                                                                                                        
print(descriptor_doc)                                                                                                                                                                         
resource_doc, create_datum = create_resource(spec='TIFF', root='/tmp', resource_path='stack.tiff', resource_kwargs={})                                                                        
print(resource_doc)                                                                                                                                                                           
datum_doc = create_datum(datum_kwargs={'slice': 5})                                                                                                                                           
print(datum_doc)                                                                                                                                                                              
event_doc = create_event(data={'motor': 0, 'image': datum_doc['datum_id']}, timestamps={'motor': 0, 'image': 0}, filled={'image': False}, seq_num=1)                                          
print(event_doc)                                                                                                                                                                              
stop_doc = create_stop()                                                                                                                                                                      
print(stop_doc)    
```