### PR TITLE
Fix document-composing functions

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -12,6 +12,7 @@ from ._version import get_versions
 
 __all__ = ['DocumentNames', 'schemas', 'compose_run']
 
+_validate = partial(jsonschema.validate, types={'array': (list, tuple)})
 
 class DocumentNames(Enum):
     stop = 'stop'
@@ -62,7 +63,7 @@ def compose_datum(*, resource, counter, datum_kwargs, validate=True):
            'datum_kwargs': datum_kwargs,
            'datum_id': '{}/{}'.format(resource_uid, next(counter))}
     if validate:
-        jsonschema.validate(DocumentNames.datum, doc)
+        jsonschema.validate(doc, schemas[DocumentNames.datum])
     return doc
 
 
@@ -79,7 +80,7 @@ def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
            'resource_kwargs': {},
            'path_semantics': path_semantics}
     if validate:
-        jsonschema.validate(DocumentNames.resource, doc)
+        jsonschema.validate(doc, schemas[DocumentNames.resource])
     return ComposeResourceBundle(
         doc,
         partial(compose_datum, resource=doc, counter=counter))
@@ -104,7 +105,7 @@ def compose_stop(*, start, event_counter, poison_pill,
            'reason': reason,
            'num_events': dict(event_counter)}
     if validate:
-        jsonschema.validate(DocumentNames.stop, doc)
+        jsonschema.validate(doc, schemas[DocumentNames.stop])
     return doc
 
 
@@ -123,7 +124,7 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
            'seq_num': seq_num,
            'filled': filled}
     if validate:
-        jsonschema.validate(DocumentNames.event, doc)
+        jsonschema.validate(doc, schemas[DocumentNames.event])
         if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):
             raise EventModelValidationError(
                 "These sets of keys must match:\n"
@@ -162,13 +163,13 @@ def compose_descriptor(*, start, streams, event_counter,
            'hints': hints,
            'configuration': configuration}
     if validate:
-        jsonschema.validate(DocumentNames.descriptor, doc)
         if name in streams and streams[name] != set(data_keys):
             raise EventModelValidationError(
                 "A descriptor with the name {} has already been composed with "
                 "data_keys {}. The requested data_keys were {}. All "
                 "descriptors in a given stream must have the same "
                 "data_keys.".format(name, streams[name], set(data_keys)))
+        jsonschema.validate(doc, schemas[DocumentNames.descriptor])
     if name not in streams:
         streams[name] = set(data_keys)
         event_counter[name] = 0
@@ -207,7 +208,7 @@ def compose_run(*, uid=None, time=None, metadata=None, validate=True):
     event_counter = {}
     poison_pill = []
     if validate:
-        jsonschema.validate(DocumentNames.start, doc)
+        jsonschema.validate(doc, schemas[DocumentNames.start])
     return ComposeRunBundle(
         doc,
         partial(compose_descriptor, start=doc, streams=streams, event_counter={}),

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -14,6 +14,7 @@ __all__ = ['DocumentNames', 'schemas', 'compose_run']
 
 _validate = partial(jsonschema.validate, types={'array': (list, tuple)})
 
+
 class DocumentNames(Enum):
     stop = 'stop'
     start = 'start'
@@ -122,7 +123,8 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
            'data': data,
            'timestamps': timestamps,
            'seq_num': seq_num,
-           'filled': filled}
+           'filled': filled,
+           'descriptor': descriptor['uid']}
     if validate:
         jsonschema.validate(doc, schemas[DocumentNames.event])
         if not (descriptor['data_keys'].keys() == data.keys() == timestamps.keys()):

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -44,8 +44,9 @@ def test_compose_run():
     assert bundle.resource_doc is resource_doc
     assert bundle.compose_datum is compose_datum
     datum_doc = compose_datum(datum_kwargs={'slice': 5})
-    compose_event(
+    event_doc = compose_event(
         data={'motor': 0, 'image': datum_doc['datum_id']},
         timestamps={'motor': 0, 'image': 0}, filled={'image': False},
         seq_num=1)
+    assert 'descriptor' in event_doc
     compose_stop()

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -30,9 +30,9 @@ def test_compose_run():
     assert bundle.compose_resource is compose_resource
     assert bundle.compose_stop is compose_stop
     bundle = compose_descriptor(
-        data_keys={'motor': {'shape': [], 'dtype': 'number'},
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
                    'image': {'shape': [512, 512], 'dtype': 'number',
-                             'external': 'FILESTORE:'}},
+                             'source': '...', 'external': 'FILESTORE:'}},
         name='primary')
     descriptor_doc, compose_event = bundle
     assert bundle.descriptor_doc is descriptor_doc


### PR DESCRIPTION
In #24 I completely misused `jsonschema.validate` and was not actually validating the documents. This PR employs actual validation and fixes a couple important bugs revealed by validation in the tests.