### PR TITLE
ENH: Add event_page, datum_page, DocumentRouter.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -356,7 +356,7 @@ def unpack_event_page_into_events(event_page):
             timestamps_list,
             filled_list or [{}] * len(data_list)):
         event = {'descriptor': descriptor,
-                 'uid': uid, 'time': time,'seq_num': seq_num,
+                 'uid': uid, 'time': time, 'seq_num': seq_num,
                  'data': data, 'timestamps': timestamps, 'filled': filled}
         yield event
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -21,9 +21,12 @@ class DocumentNames(Enum):
     start = 'start'
     descriptor = 'descriptor'
     event = 'event'
-    bulk_events = 'bulk_events'
     datum = 'datum'
     resource = 'resource'
+    event_page = 'event_page'
+    datum_page = 'datum_page'
+    bulk_datum = 'bulk_datum'  # deprecated
+    bulk_events = 'bulk_events'  # deprecated
 
 
 class DocumentRouter:
@@ -101,19 +104,19 @@ class DocumentRouter:
     def datum_page(self, doc):
         return doc
 
-    def bulk_event(self, doc):
+    def bulk_events(self, doc):
         # Do not modify this in a subclass. Use event_page.
         warnings.warn(
-            "The name 'bulk_event' has been deprecated in favor of "
-            "'event_page'.")
-        return self.event_page(doc)
+            "The document type 'bulk_events' has been deprecated in favor of "
+            "'event_page', whose structure is a transpose of 'bulk_events'.")
+        return self.event_page(bulk_events_to_event_page(doc))
 
     def bulk_datum(self, doc):
         # Do not modify this in a subclass. Use event_page.
         warnings.warn(
-            "The name 'bulk_datum' has been deprecated in favor of "
-            "'datum_page'.")
-        return self.datum_page(doc)
+            "The document type 'bulk_datum' has been deprecated in favor of "
+            "'datum_page', whose structure is a transpose of 'bulk_datum'.")
+        return self.datum_page(bulk_datum_to_datum_page(doc))
 
 
 class EventModelError(Exception):
@@ -330,4 +333,12 @@ def pack_datum_into_datum_page(datum):
 
 
 def unpack_datum_page_into_datum(datum_page):
+    ...
+
+
+def bulk_events_to_event_page(bulk_event):
+    ...
+
+
+def bulk_datum_to_datum_page(bulk_datum):
     ...

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -395,7 +395,7 @@ def bulk_events_to_event_pages(bulk_events):
 
 def bulk_datum_to_datum_page(bulk_datum):
     datum_kwargs = defaultdict(list)
-    for dk in data_kwargs_list:
+    for dk in bulk_datum['data_kwargs_list']:
         for k, v in dk.items():
             datum_kwargs[k].append(v)
     datum_page = {'datum_id': bulk_datum['datum_ids'],

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -354,7 +354,7 @@ def unpack_event_page_into_events(event_page):
             event_page['seq_num'],
             data_list,
             timestamps_list,
-            filled_list):
+            filled_list or [{}] * len(data_list)):
         event = {'descriptor': descriptor,
                  'uid': uid, 'time': time,'seq_num': seq_num,
                  'data': data, 'timestamps': timestamps, 'filled': filled}

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -86,15 +86,15 @@ class DocumentRouter:
         return doc
 
     def event(self, doc):
-        event_page = pack_event_into_event_page(doc)
+        event_page = pack_events_into_event_page(doc)
         output_event_page = self.event_page(event_page)
-        output_event = unpack_event_page_into_event(output_event_page)
+        output_event, = unpack_event_page_into_events(output_event_page)
         return output_event
 
     def datum(self, doc):
         datum_page = pack_datum_into_datum_page(doc)
         output_datum_page = self.datum_page(datum_page)
-        output_datum = unpack_datum_page_into_datum(output_datum_page)
+        output_datum, = unpack_datum_page_into_datum(output_datum_page)
         return output_datum
 
     def event_page(self, doc):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from collections import defaultdict, namedtuple
 import json
 import jsonschema
 from enum import Enum
@@ -116,8 +116,7 @@ class DocumentRouter:
         warnings.warn(
             "The document type 'bulk_datum' has been deprecated in favor of "
             "'datum_page', whose structure is a transpose of 'bulk_datum'.")
-        for page in bulk_datum_to_datum_page(doc):
-            self.datum_page(page)
+        self.datum_page(bulk_datum_to_datum_page(doc))
 
 
 class EventModelError(Exception):
@@ -395,6 +394,10 @@ def bulk_events_to_event_pages(bulk_events):
 
 
 def bulk_datum_to_datum_page(bulk_datum):
-    return {'datum_id': [datum['datum_id'] for datum in bulk_datum],
-            'datum_kwargs': [datum['datum_kwargs'] for datum in bulk_datum],
-            'resource': [datum['resource'] for datum in bulk_datum]}
+    datum_kwargs = defaultdict(list)
+    for dk in data_kwargs_list:
+        for k, v in dk.items():
+            datum_kwargs[k].append(v)
+    datum_page = {'datum_id': bulk_datum['datum_ids'],
+                  'resource': bulk_datum['resource'],
+                  'datum_kwargs': dict(datum_kwargs)}

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -86,15 +86,15 @@ class DocumentRouter:
         return doc
 
     def event(self, doc):
-        event_page = pack_events_into_event_page(doc)
+        event_page = pack_event_page(doc)
         output_event_page = self.event_page(event_page)
-        output_event, = unpack_event_page_into_events(output_event_page)
+        output_event, = unpack_event_page(output_event_page)
         return output_event
 
     def datum(self, doc):
-        datum_page = pack_datum_into_datum_page(doc)
+        datum_page = pack_datum_page(doc)
         output_datum_page = self.datum_page(datum_page)
-        output_datum, = unpack_datum_page_into_datum(output_datum_page)
+        output_datum, = unpack_datum_page(output_datum_page)
         return output_datum
 
     def event_page(self, doc):
@@ -321,7 +321,7 @@ def compose_run(*, uid=None, time=None, metadata=None, validate=True):
                 poison_pill=poison_pill))
 
 
-def pack_events_into_event_page(*events):
+def pack_event_page(*events):
     time_list = []
     uid_list = []
     seq_num_list = []
@@ -343,7 +343,7 @@ def pack_events_into_event_page(*events):
     return event_page
 
 
-def unpack_event_page_into_events(event_page):
+def unpack_event_page(event_page):
     descriptor = event_page['descriptor']
     data_list = _transpose_dict_of_lists(event_page['data'])
     timestamps_list = _transpose_dict_of_lists(event_page['timestamps'])
@@ -361,7 +361,7 @@ def unpack_event_page_into_events(event_page):
         yield event
 
 
-def pack_datum_into_datum_page(*datum):
+def pack_datum_page(*datum):
     datum_id_list = []
     datum_kwargs_list = []
     for datum_ in datum:
@@ -373,7 +373,7 @@ def pack_datum_into_datum_page(*datum):
     return datum_page
 
 
-def unpack_datum_page_into_datum(datum_page):
+def unpack_datum_page(datum_page):
     resource = datum_page['resource']
     datum_kwargs_list = _transpose_dict_of_lists(datum_page['datum_kwargs'])
     for datum_id, datum_kwargs in zip(

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -363,22 +363,22 @@ def unpack_event_page(event_page):
 
 def pack_datum_page(*datum):
     datum_id_list = []
-    datum_kwargs_list = []
+    datum_kwarg_list = []
     for datum_ in datum:
         datum_id_list.append(datum_['datum_id'])
-        datum_kwargs_list.append(datum_['datum_kwargs'])
+        datum_kwarg_list.append(datum_['datum_kwargs'])
     datum_page = {'resource': datum_['resource'],
                   'datum_id': datum_id_list,
-                  'datum_kwargs': _transpose_list_of_dicts(datum_kwargs_list)}
+                  'datum_kwargs': _transpose_list_of_dicts(datum_kwarg_list)}
     return datum_page
 
 
 def unpack_datum_page(datum_page):
     resource = datum_page['resource']
-    datum_kwargs_list = _transpose_dict_of_lists(datum_page['datum_kwargs'])
+    datum_kwarg_list = _transpose_dict_of_lists(datum_page['datum_kwargs'])
     for datum_id, datum_kwargs in zip(
             datum_page['datum_id'],
-            datum_kwargs_list):
+            datum_kwarg_list):
         datum = {'datum_id': datum_id, 'datum_kwargs': datum_kwargs,
                  'resource': resource}
         yield datum
@@ -419,7 +419,7 @@ def bulk_datum_to_datum_page(bulk_datum):
     datum_page = {'datum_id': bulk_datum['datum_ids'],
                   'resource': bulk_datum['resource'],
                   'datum_kwargs': _transpose_list_of_dicts(
-                      bulk_datum['datum_kwargs_list'])}
+                      bulk_datum['datum_kwarg_list'])}
     return datum_page
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -136,10 +136,14 @@ SCHEMA_PATH = 'schemas'
 SCHEMA_NAMES = {DocumentNames.start: 'schemas/run_start.json',
                 DocumentNames.stop: 'schemas/run_stop.json',
                 DocumentNames.event: 'schemas/event.json',
-                DocumentNames.bulk_events: 'schemas/bulk_events.json',
+                DocumentNames.event_page: 'schemas/event_page.json',
                 DocumentNames.descriptor: 'schemas/event_descriptor.json',
                 DocumentNames.datum: 'schemas/datum.json',
-                DocumentNames.resource: 'schemas/resource.json'}
+                DocumentNames.datum_page: 'schemas/datum_page.json',
+                DocumentNames.resource: 'schemas/resource.json',
+                # DEPRECATED:
+                DocumentNames.bulk_events: 'schemas/bulk_events.json',
+                DocumentNames.bulk_datum: 'schemas/bulk_datum.json'}
 schemas = {}
 for name, filename in SCHEMA_NAMES.items():
     with open(rs_fn('event_model', filename)) as fin:

--- a/event_model/schemas/bulk_datum.json
+++ b/event_model/schemas/bulk_datum.json
@@ -1,0 +1,25 @@
+{
+    "properties": {
+        "datum_kwargs": {
+            "type": "object",
+            "description": "Arguments to pass to the Handler to retrieve one quanta of data"
+        },
+        "resource": {
+            "type": "string",
+            "description": "The UID of the Resource to which this Datum belongs"
+        },
+        "datum_id": {
+            "type": "string",
+            "description": "Globally unique identifier for this Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
+        }
+    },
+    "required": [
+        "datum_kwargs",
+        "resource",
+        "datum_id"
+    ],
+    "additionalProperties": false,
+    "type": "object",
+    "title": "datum",
+    "description": "Document to reference a quanta of externally-stored data"
+}

--- a/event_model/schemas/bulk_datum.json
+++ b/event_model/schemas/bulk_datum.json
@@ -1,7 +1,8 @@
 {
     "properties": {
         "datum_kwargs": {
-            "type": "object",
+            "type": "array",
+            "items": {"type": "object"},
             "description": "Arguments to pass to the Handler to retrieve one quanta of data"
         },
         "resource": {
@@ -9,7 +10,8 @@
             "description": "The UID of the Resource to which this Datum belongs"
         },
         "datum_id": {
-            "type": "string",
+            "type": "array",
+            "items": {"type": "string"},
             "description": "Globally unique identifier for this Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
         }
     },

--- a/event_model/schemas/bulk_datum.json
+++ b/event_model/schemas/bulk_datum.json
@@ -22,6 +22,6 @@
     ],
     "additionalProperties": false,
     "type": "object",
-    "title": "datum",
+    "title": "bulk_datum",
     "description": "Document to reference a quanta of externally-stored data"
 }

--- a/event_model/schemas/bulk_datum.json
+++ b/event_model/schemas/bulk_datum.json
@@ -1,18 +1,18 @@
 {
     "properties": {
-        "datum_kwargs": {
+        "datum_kwargs_list": {
             "type": "array",
             "items": {"type": "object"},
-            "description": "Arguments to pass to the Handler to retrieve one quanta of data"
+            "description": "Array of arguments to pass to the Handler to retrieve one quanta of data"
         },
         "resource": {
             "type": "string",
-            "description": "The UID of the Resource to which this Datum belongs"
+            "description": "UID of the Resource to which all these Datum documents belong"
         },
-        "datum_id": {
+        "datum_ids": {
             "type": "array",
             "items": {"type": "string"},
-            "description": "Globally unique identifier for this Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
+            "description": "Globally unique identifiers for each Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
         }
     },
     "required": [

--- a/event_model/schemas/bulk_events.json
+++ b/event_model/schemas/bulk_events.json
@@ -44,7 +44,7 @@
                 ],
                 "additionalProperties": false,
                 "type": "object",
-                "title": "event",
+                "title": "bulk_events",
                 "description": "Document to record a quanta of collected data"
             }
         }

--- a/event_model/schemas/bulk_events.json
+++ b/event_model/schemas/bulk_events.json
@@ -4,7 +4,6 @@
             "type": "array",
             "items": {
                 "type": "object",
-
                 "properties": {
                     "data": {
                         "type": "object",
@@ -14,10 +13,10 @@
                         "type": "object",
                         "description": "The timestamps of the individual measument data"
                     },
-		    "filled": {
-			"type": "object",
-			"description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
-		    },
+                    "filled": {
+                        "type": "object",
+                        "description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
+                    },
                     "descriptor": {
                         "type": "string",
                         "description": "UID to point back to Descriptor for this event stream"

--- a/event_model/schemas/datum_page.json
+++ b/event_model/schemas/datum_page.json
@@ -1,0 +1,33 @@
+{
+    "definitions": {
+        "dataframe": {
+            "title": "dataframe",
+            "description": "A DataFrame-like object",
+            "additionalProperties": {"type": "array"}
+        }
+    },
+    "properties": {
+        "resource": {
+            "type": "string",
+            "description": "The UID of the Resource to which all Datums in the page belong"
+        },
+        "datum_kwargs": {
+            "type": "dataframe",
+            "description": "Array of arguments to pass to the Handler to retrieve one quanta of data"
+        },
+        "datum_id": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Array unique identifiers for each Datum (akin to 'uid' for other Document types), typically formatted as '<resource>/<integer>'"
+        }
+    },
+    "required": [
+        "resource",
+        "datum_kwargs",
+        "datum_id"
+    ],
+    "additionalProperties": false,
+    "type": "object",
+    "title": "datum",
+    "description": "Page of documents to reference a quanta of externally-stored data"
+}

--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -10,6 +10,7 @@
         },
         "filled": {
             "type": "object",
+            "additionalProperties": {"type": ["boolean", "string"]},
             "description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
         },
         "descriptor": {

--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -14,7 +14,7 @@
         },
         "descriptor": {
             "type": "string",
-            "description": "UID to point back to Descriptor for this event stream"
+            "description": "UID of the EventDescriptor to which this Event belongs"
         },
         "seq_num": {
             "type": "integer",
@@ -22,7 +22,7 @@
         },
         "time": {
             "type": "number",
-            "description": "The event time.  This maybe different than the timestamps on each of the data entries"
+            "description": "The event time. This maybe different than the timestamps on each of the data entries."
         },
         "uid": {
             "type": "string",

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -54,6 +54,6 @@
     ],
     "additionalProperties": false,
     "type": "object",
-    "title": "event",
+    "title": "event_page",
     "description": "Page of documents to record a quanta of collected data"
 }

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -1,0 +1,59 @@
+{
+    "definitions": {
+        "dataframe": {
+            "title": "dataframe",
+            "description": "A DataFrame-like object",
+            "additionalProperties": {"type": "array"}
+        },
+        "dataframe_for_filled": {
+            "title": "dataframe_for_filled",
+            "description": "A DataFrame-like object with boolean or string entries",
+            "additionalProperties": {"type": "array", "items": {"type": ["boolean", "string"]}}
+        }
+    },
+    "properties": {
+        "descriptor": {
+            "type": "string",
+            "description": "The UID of the EventDescriptor to which all of the Events in this page belong"
+        },
+        "data": {
+            "type": "dataframe",
+            "description": "The actual measurement data"
+        },
+        "timestamps": {
+            "type": "dataframe",
+            "description": "The timestamps of the individual measurement data"
+        },
+        "filled": {
+            "type": "dataframe_for_filled",
+            "description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
+        },
+        "seq_num": {
+            "type": "array",
+            "items": {"type": "integer"},
+            "description": "Array of sequence numbers to identify the location of each Event in the Event stream"
+        },
+        "time": {
+            "type": "array",
+            "items": {"type": "number"},
+            "description": "Array of Event times. This maybe different than the timestamps on each of the data entries"
+        },
+        "uid": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Array of globally unique identifiers for each Event"
+        }
+    },
+    "required": [
+        "descriptor",
+        "uid",
+        "data",
+        "timestamps",
+        "time",
+        "seq_num"
+    ],
+    "additionalProperties": false,
+    "type": "object",
+    "title": "event",
+    "description": "Page of documents to record a quanta of collected data"
+}

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -79,3 +79,6 @@ def test_round_trip_pagination():
     actual = event_model.unpack_datum_page_into_datum(
         event_model.pack_datum_into_datum_page(expected))
     assert actual == expected
+
+
+def test_bulk_events_to_event_page():

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -105,7 +105,7 @@ def test_bulk_events_to_event_page():
         timestamps={'motor': 0, 'image': 0}, filled={'image': False},
         seq_num=2)
     event3 = desc_bundle_baseline.compose_event(
-        data={'motor': 0}, 
+        data={'motor': 0},
         timestamps={'motor': 0},
         seq_num=1)
 
@@ -118,31 +118,11 @@ def test_bulk_events_to_event_page():
 
 def test_bulk_datum_to_datum_page():
     run_bundle = event_model.compose_run()
-    desc_bundle = run_bundle.compose_descriptor(
-        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
-                   'image': {'shape': [512, 512], 'dtype': 'number',
-                             'source': '...', 'external': 'FILESTORE:'}},
-        name='primary')
-    desc_bundle_baseline = run_bundle.compose_descriptor(
-        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
-        name='baseline')
     res_bundle = run_bundle.compose_resource(
         spec='TIFF', root='/tmp', resource_path='stack.tiff',
         resource_kwargs={})
     datum1 = res_bundle.compose_datum(datum_kwargs={'slice': 5})
     datum2 = res_bundle.compose_datum(datum_kwargs={'slice': 10})
-    event1 = desc_bundle.compose_event(
-        data={'motor': 0, 'image': datum1['datum_id']},
-        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
-        seq_num=1)
-    event2 = desc_bundle.compose_event(
-        data={'motor': 0, 'image': datum2['datum_id']},
-        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
-        seq_num=2)
-    event3 = desc_bundle_baseline.compose_event(
-        data={'motor': 0},
-        timestamps={'motor': 0},
-        seq_num=1)
 
     actual = event_model.pack_datum_into_datum_page(datum1, datum2)
     bulk_datum = {'resource': res_bundle.resource_doc['uid'],

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -5,12 +5,12 @@ def test_documents():
     dn = event_model.DocumentNames
     for k in ('stop', 'start', 'descriptor',
               'event', 'bulk_events', 'datum',
-              'resource'):
+              'resource', 'bulk_datum', 'event_page', 'datum_page'):
         assert dn(k) == getattr(dn, k)
 
 
 def test_len():
-    assert 7 == len(event_model.DocumentNames)
+    assert 10 == len(event_model.DocumentNames)
 
 
 def test_schemas():

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -126,8 +126,8 @@ def test_bulk_datum_to_datum_page():
 
     actual = event_model.pack_datum_page(datum1, datum2)
     bulk_datum = {'resource': res_bundle.resource_doc['uid'],
-                  'datum_kwargs_list': [datum1['datum_kwargs'],
-                                        datum2['datum_kwargs']],
+                  'datum_kwarg_list': [datum1['datum_kwargs'],
+                                       datum2['datum_kwargs']],
                   'datum_ids': [datum1['datum_id'], datum2['datum_id']]}
     expected = event_model.bulk_datum_to_datum_page(bulk_datum)
     assert actual == expected

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -70,14 +70,14 @@ def test_round_trip_pagination():
 
     # Round trip event -> event_page -> event.
     expected = event_doc
-    actual, = event_model.unpack_event_page_into_events(
-        event_model.pack_events_into_event_page(expected))
+    actual, = event_model.unpack_event_page(
+        event_model.pack_event_page(expected))
     assert actual == expected
 
     # Round trip datum -> datum_page -> datum.
     expected = datum_doc
-    actual, = event_model.unpack_datum_page_into_datum(
-        event_model.pack_datum_into_datum_page(expected))
+    actual, = event_model.unpack_datum_page(
+        event_model.pack_datum_page(expected))
     assert actual == expected
 
 
@@ -109,8 +109,8 @@ def test_bulk_events_to_event_page():
         timestamps={'motor': 0},
         seq_num=1)
 
-    primary_event_page = event_model.pack_events_into_event_page(event1, event2)
-    baseline_event_page = event_model.pack_events_into_event_page(event3)
+    primary_event_page = event_model.pack_event_page(event1, event2)
+    baseline_event_page = event_model.pack_event_page(event3)
     bulk_events = {'primary': [event1, event2], 'baseline': [event3]}
     pages = event_model.bulk_events_to_event_pages(bulk_events)
     assert tuple(pages) == (primary_event_page, baseline_event_page)
@@ -124,7 +124,7 @@ def test_bulk_datum_to_datum_page():
     datum1 = res_bundle.compose_datum(datum_kwargs={'slice': 5})
     datum2 = res_bundle.compose_datum(datum_kwargs={'slice': 10})
 
-    actual = event_model.pack_datum_into_datum_page(datum1, datum2)
+    actual = event_model.pack_datum_page(datum1, datum2)
     bulk_datum = {'resource': res_bundle.resource_doc['uid'],
                   'datum_kwargs_list': [datum1['datum_kwargs'],
                                         datum2['datum_kwargs']],

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -114,3 +114,40 @@ def test_bulk_events_to_event_page():
     bulk_events = {'primary': [event1, event2], 'baseline': [event3]}
     pages = event_model.bulk_events_to_event_pages(bulk_events)
     assert tuple(pages) == (primary_event_page, baseline_event_page)
+
+
+def test_bulk_datum_to_datum_page():
+    run_bundle = event_model.compose_run()
+    desc_bundle = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
+                   'image': {'shape': [512, 512], 'dtype': 'number',
+                             'source': '...', 'external': 'FILESTORE:'}},
+        name='primary')
+    desc_bundle_baseline = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
+        name='baseline')
+    res_bundle = run_bundle.compose_resource(
+        spec='TIFF', root='/tmp', resource_path='stack.tiff',
+        resource_kwargs={})
+    datum1 = res_bundle.compose_datum(datum_kwargs={'slice': 5})
+    datum2 = res_bundle.compose_datum(datum_kwargs={'slice': 10})
+    event1 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': datum1['datum_id']},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
+        seq_num=1)
+    event2 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': datum2['datum_id']},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': False},
+        seq_num=2)
+    event3 = desc_bundle_baseline.compose_event(
+        data={'motor': 0},
+        timestamps={'motor': 0},
+        seq_num=1)
+
+    actual = event_model.pack_datum_into_datum_page(datum1, datum2)
+    bulk_datum = {'resource': res_bundle.resource_doc['uid'],
+                  'datum_kwargs_list': [datum1['datum_kwargs'],
+                                        datum2['datum_kwargs']],
+                  'datum_ids': [datum1['datum_id'], datum2['datum_id']]}
+    expected = event_model.bulk_datum_to_datum_page(bulk_datum)
+    assert actual == expected


### PR DESCRIPTION
This is a sequel to `bluesky.callbacks.CallbackBase`.

Improvements:
* By putting it in event-model, packages like suitcase-csv can use it without importing bluesky as a run dependency.
* It returns things, which makes it useful in pipelines.
* We can take this opportunity to adopt a name that correctly suggests that its usefulness isn't confined to callbacks.

I have also sketched out `event_page` (seems like the consensus choice?) and `datum_page` (still contentious) ~as aliases for `bulk_event` and `bulk_datum`~. A `bulk_event` and `bulk_datum` uses a "list of dicts" representation. An `event_page` and `datum_page` use a "dict of lists" DataFrame-like representation. A have added schemas for the new `event_page` and `datum_page` concepts and, belatedly, added a schema for `bulk_datum`. Both of the `bulk_*` representations are deprecated.

<hr />

Edit: I should be sure to credit @CJ-Wright for advocating for the second bullet point above in https://github.com/NSLS-II/bluesky/pull/1122.