### PR TITLE
ENH: Add Filler.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -127,8 +127,8 @@ class Filler(DocumentRouter):
     Filler manages caches of potentially expensive resources (e.g. large data
     in memory) managing its lifecycle is important. If used as a context
     manager, it will drop references to its caches upon exit from the
-    context. Unless the user holds additionally references to those caches,
-    they will be garbage collected.
+    context. Unless the user holds additional references to those caches, they
+    will be garbage collected.
 
     But for some applications, such as taking multiple passes over the same
     data, it may be useful to keep a longer-lived Filler instance and then
@@ -151,9 +151,10 @@ class Filler(DocumentRouter):
 
             handler_instance(**datum_kwargs)
 
-        As implied by the names, this is typically implemented using a class that
-        implements ``__init__`` and ``__call__``, with the respective signatures.
-        In general it may be any callable-that-returns-a-callable.
+        As the names 'handler class' and 'handler instance' suggest, this is
+        typically implemented using a class that implements ``__init__`` and
+        ``__call__``, with the respective signatures. But in general it may be
+        any callable-that-returns-a-callable.
     include : Iterable
         The set of fields to fill. By default all unfilled fields are filled.
         This parameter is mutually incompatible with the ``exclude`` parameter.

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -213,6 +213,7 @@ class Filler(DocumentRouter):
         self.retry_intervals = list(retry_intervals)
         self.include = include
         self.exclude = exclude
+        self._closed = False
 
     @staticmethod
     def get_default_datum_cache():
@@ -306,15 +307,25 @@ class Filler(DocumentRouter):
         # them it's the user's problem to manage their lifecycle. If the user
         # does not (e.g. they are the default caches) the gc will look after
         # them.
+        self._closed = True
         self._handler_cache = None
         self._datum_cache = None
 
+    def __call__(self, name, doc, validate=False):
+        if self._closed:
+            raise EventModelRuntimeError(
+                "This Filler has been closed and is no longer usable.")
+        super().__call__(name, doc, validate)
 
 class EventModelError(Exception):
     ...
 
 
 class EventModelValueError(EventModelError, ValueError):
+    ...
+
+
+class EventModelRuntimeError(EventModelError, RuntimeError):
     ...
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -284,7 +284,7 @@ class Filler(DocumentRouter):
                         actual_data = handler(**datum_doc['datum_kwargs'])
                         doc['data'][key] = actual_data
                         doc['filled'][key] = datum_id
-                    except OSError as error_:
+                    except IOError as error_:
                         # The file may not be visible on the network yet.
                         # Wait and try again. Stash the error in a variable
                         # that we can access later if we run out of attempts.
@@ -294,7 +294,9 @@ class Filler(DocumentRouter):
                 else:
                     # We have used up all our attempts. There seems to be an
                     # actual problem. Raise the error stashed above.
-                    raise error
+                    raise DataNotAccessible(
+                        "Filler was unable to load the data referenced by the "
+                        "Datum document {datum_doc}.") from error
         return doc
 
     def descriptor(self, doc):
@@ -340,6 +342,11 @@ class EventModelValidationError(EventModelError):
 
 class UnfilledData(EventModelError):
     """raised when unfilled data is found"""
+    ...
+
+
+class DataNotAccessible(EventModelError, IOError):
+    """raised when attempts to load data referenced by Datum document fail"""
     ...
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -317,6 +317,7 @@ class Filler(DocumentRouter):
                 "This Filler has been closed and is no longer usable.")
         super().__call__(name, doc, validate)
 
+
 class EventModelError(Exception):
     ...
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -281,6 +281,11 @@ class Filler(DocumentRouter):
                     ttime.sleep(interval)
                     try:
                         handler = self._handler_cache[datum_doc['resource']]
+                    except KeyError as err:
+                        raise EventModelKeyError(
+                            f"Datum document references a Resource that has "
+                            f"not yet been seen. Datum document: {datum_doc}") from err
+                    try:
                         actual_data = handler(**datum_doc['datum_kwargs'])
                         doc['data'][key] = actual_data
                         doc['filled'][key] = datum_id
@@ -328,6 +333,10 @@ class Filler(DocumentRouter):
 
 
 class EventModelError(Exception):
+    ...
+
+
+class EventModelKeyError(EventModelError, KeyError):
     ...
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -237,6 +237,9 @@ class Filler(DocumentRouter):
         self.retry_intervals = list(retry_intervals)
         self._closed = False
 
+    def __repr__(self):
+        return "<Filler>" if not self._closed else "<Closed Filler>"
+
     @staticmethod
     def get_default_resource_cache():
         return {}

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -197,13 +197,15 @@ class Filler(DocumentRouter):
 
     >>> with Filler(handler_registry) as filler:
     ...     for name, doc in stream:
-    ...         filler(name, doc)
+    ...         filler(name, doc)  # mutates doc in place
+    ...         # Do some analysis or export with name and doc.
 
     Or as a long-lived object.
 
     >>> f = Filler(handler_registry)
     >>> for name, doc in stream:
-    ...     filler(name, doc)
+    ...     filler(name, doc)  # mutates doc in place
+    ...     # Do some analysis or export with name and doc.
     ...
     >>> del filler  # Free up memory from potentially large caches.
     """

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -344,7 +344,7 @@ class Filler(DocumentRouter):
         if self._closed:
             raise EventModelRuntimeError(
                 "This Filler has been closed and is no longer usable.")
-        super().__call__(name, doc, validate)
+        return super().__call__(name, doc, validate)
 
 
 class EventModelError(Exception):

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -308,7 +308,7 @@ class Filler(DocumentRouter):
     def __enter__(self):
         return self
 
-    def __exit__(self, *exc_details):
+    def close(self):
         # Drop references to the caches. If the user holds another reference to
         # them it's the user's problem to manage their lifecycle. If the user
         # does not (e.g. they are the default caches) the gc will look after
@@ -316,6 +316,9 @@ class Filler(DocumentRouter):
         self._closed = True
         self._handler_cache = None
         self._datum_cache = None
+
+    def __exit__(self, *exc_details):
+        self.close()
 
     def __call__(self, name, doc, validate=False):
         if self._closed:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -194,7 +194,7 @@ class Filler(DocumentRouter):
                         handler = self.handlers[datum_doc['resource']]
                         actual_data = handler(**datum_doc['datum_kwargs'])
                         doc['data'][key] = actual_data
-                        doc['filled'][key] = True
+                        doc['filled'][key] = datum_id
                     except OSError as error_:
                         # The file may not be visible on the network yet.
                         # Wait and try again. Stash the error in a variable

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -241,7 +241,12 @@ class Filler(DocumentRouter):
         return doc
 
     def resource(self, doc):
-        handler_class = self.handler_registry[doc['spec']]
+        try:
+            handler_class = self.handler_registry[doc['spec']]
+        except KeyError as err:
+            raise UndefinedAssetSpecification(
+                f"Resource document refers to spec {doc['spec']!r} which is "
+                f"not defined in the Filler's handler registry.") from err
         handler = handler_class(doc['resource_path'],
                                 root=doc['root'],
                                 **doc['resource_kwargs'])
@@ -364,6 +369,11 @@ class EventModelValidationError(EventModelError):
 
 class UnfilledData(EventModelError):
     """raised when unfilled data is found"""
+    ...
+
+
+class UndefinedAssetSpecification(EventModelKeyError):
+    """raised when a resource spec is missing from the handler registry"""
     ...
 
 

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -402,7 +402,7 @@ def compose_resource(*, start, spec, root, resource_path, resource_kwargs,
            'spec': spec,
            'root': root,
            'resource_path': resource_path,
-           'resource_kwargs': {},
+           'resource_kwargs': resource_kwargs,
            'path_semantics': path_semantics}
     if validate:
         jsonschema.validate(doc, schemas[DocumentNames.resource])

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -120,7 +120,6 @@ class DocumentRouter:
         self.datum_page(bulk_datum_to_datum_page(doc))
 
 
-
 class Filler:
     """Pass documents through, loading any externally-referenced data."""
     ATTEMPTS = 10

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -120,11 +120,6 @@ class DocumentRouter:
         self.datum_page(bulk_datum_to_datum_page(doc))
 
 
-# In total wait about 2 seconds before giving up.
-# Max sleep, between the final two attempts, is about 1 second.
-DEFAULT_RETRY_INTERVALS = tuple(0.001 * numpy.array([2**i for i in range(11)]))
-
-
 class Filler(DocumentRouter):
     """Pass documents through, loading any externally-referenced data.
 
@@ -211,7 +206,8 @@ class Filler(DocumentRouter):
     def __init__(self, handler_registry, *,
                  include=None, exclude=None,
                  handler_cache=None, resource_cache=None, datum_cache=None,
-                 retry_intervals=DEFAULT_RETRY_INTERVALS):
+                 retry_intervals=(0.001, 0.002, 0.004, 0.008, 0.016, 0.032,
+                                  0.064, 0.128, 0.256, 0.512, 1.024)):
         if include is not None and exclude is not None:
             raise EventModelValueError(
                 "The parameters `include` and `exclude` are mutually "

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -189,7 +189,7 @@ class Filler(DocumentRouter):
         if handler_cache is None:
             handler_cache = self.get_default_handler_cache()
         if datum_cache is None:
-            datum_cache = self.get_dfeault_datum_cache()
+            datum_cache = self.get_default_datum_cache()
         self._handler_cache = handler_cache
         self._datum_cache = datum_cache
         if retry_intervals is None:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -125,7 +125,8 @@ class Filler:
     """Pass documents through, loading any externally-referenced data."""
     ATTEMPTS = 10
 
-    def __init__(self, handler_registry, handler_cache=None, datum_cache=None):
+    def __init__(self, handler_registry, *,
+                 handler_cache=None, datum_cache=None):
         self.handler_registry = handler_registry
         if handler_cache is None:
             handler_cache = {}

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -245,7 +245,8 @@ class Filler(DocumentRouter):
             handler_class = self.handler_registry[doc['spec']]
         except KeyError as err:
             raise UndefinedAssetSpecification(
-                f"Resource document refers to spec {doc['spec']!r} which is "
+                f"Resource document with uid {doc['uid']} "
+                f"refers to spec {doc['spec']!r} which is "
                 f"not defined in the Filler's handler registry.") from err
         handler = handler_class(doc['resource_path'],
                                 root=doc['root'],

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -172,7 +172,7 @@ class Filler:
                         error = error_
                     else:
                         break
-                    time.sleep(interval)
+                    ttime.sleep(interval)
                     # Back off how quickly we attempt each time.
                     interval *= 2
                 else:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -126,7 +126,7 @@ class Filler(DocumentRouter):
     It is recommended to use the Filler as a context manager.  Because the
     Filler manages caches of potentially expensive resources (e.g. large data
     in memory) managing its lifecycle is important. If used as a context
-    manager, it will drops it references to its caches upon exit from the
+    manager, it will drop references to its caches upon exit from the
     context. Unless the user holds additionally references to those caches,
     they will be garbage collected.
 
@@ -162,7 +162,7 @@ class Filler(DocumentRouter):
         If data is not found on the first try, there may a race between the
         I/O systems creating the external data and this stream of Documents
         that reference it. If Filler encounters an ``IOError`` it will wait a
-        bit and retry. This list specifies how long tosleep (in seconds)
+        bit and retry. This list specifies how long to sleep (in seconds)
         between subsequent attempts. An empty list means, "Try only once." If
         None, a sensible default is used. That default should not be considered
         stable; it may change at any time as the authors tune it.
@@ -193,7 +193,7 @@ class Filler(DocumentRouter):
         self._handler_cache = handler_cache
         self._datum_cache = datum_cache
         if retry_intervals is None:
-            # Total wait of about 2 seconds before giving up.
+            # Total wait about 2 seconds before giving up.
             # Max sleep, between the final two attempts, is about 1 second.
             retry_intervals = 0.001 * numpy.array([2**i for i in range(11)])
         self.retry_intervals = list(retry_intervals)

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -176,9 +176,19 @@ class Filler(DocumentRouter):
         I/O systems creating the external data and this stream of Documents
         that reference it. If Filler encounters an ``IOError`` it will wait a
         bit and retry. This list specifies how long to sleep (in seconds)
-        between subsequent attempts. None means, "Try only once." By default, a
-        sequence of several retries is used. That default should not be
-        considered stable; it may change at any time as the authors tune it.
+        between subsequent attempts. Set to ``None`` to try only once before
+        raising ``DataNotAccessible``. A subclass may catch this exception and
+        implement a different retry mechanism --- for example using a different
+        implementation of sleep from an async framework.  But by default, a
+        sequence of several retries with increasing sleep intervals is used.
+        The default sequence should not be considered stable; it may change at
+        any time as the authors tune it.
+
+    Raises
+    ------
+    DataNotAccessible
+        If an IOError is raised when loading the data after the configured
+        number of attempts. See the ``retry_intervals`` parameter for details.
 
     Examples
     --------

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -295,8 +295,8 @@ class Filler(DocumentRouter):
                     # We have used up all our attempts. There seems to be an
                     # actual problem. Raise the error stashed above.
                     raise DataNotAccessible(
-                        "Filler was unable to load the data referenced by the "
-                        "Datum document {datum_doc}.") from error
+                        f"Filler was unable to load the data referenced by "
+                        f"the Datum document {datum_doc}.") from error
         return doc
 
     def descriptor(self, doc):

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -290,3 +290,27 @@ def test_filler():
         filler('stop', stop_doc)
         assert not filler._closed
     assert event['data']['image'].shape == (5, 5)
+
+    class DummyHandlerRootMapTest:
+        def __init__(self, resource_path, a, b):
+            assert a == 1
+            assert b == 2
+            assert resource_path == '/tmp/moved/stack.tiff'
+
+        def __call__(self, c, d):
+            assert c == 3
+            assert d == 4
+            return numpy.ones((5, 5))
+
+    with event_model.Filler({'DUMMY': DummyHandlerRootMapTest},
+                            root_map={'/tmp': '/tmp/moved'}) as filler:
+        filler('start', run_bundle.start_doc)
+        filler('descriptor', desc_bundle.descriptor_doc)
+        filler('descriptor', desc_bundle_baseline.descriptor_doc)
+        filler('resource', res_bundle.resource_doc)
+        filler('datum', datum_doc)
+        event = copy.deepcopy(raw_event)
+        filler('event', event)
+        filler('stop', stop_doc)
+        assert not filler._closed
+    assert event['data']['image'].shape == (5, 5)

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -179,11 +179,10 @@ def test_document_router_smoke_test():
 def test_filler():
 
     class DummyHandler:
-        def __init__(self, resource_path, root, a, b):
+        def __init__(self, resource_path, a, b):
             assert a == 1
             assert b == 2
-            assert resource_path == 'stack.tiff'
-            assert root == '/tmp'
+            assert resource_path == '/tmp/stack.tiff'
 
         def __call__(self, c, d):
             assert c == 3

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -225,7 +225,6 @@ def test_filler():
     assert filler._closed
 
     # Test context manager
-
     with event_model.Filler(reg) as filler:
         filler('start', run_bundle.start_doc)
         filler('descriptor', desc_bundle.descriptor_doc)
@@ -238,6 +237,14 @@ def test_filler():
         assert not filler._closed
     assert event['data']['image'].shape == (5, 5)
     assert filler._closed
+
+    # Test undefined handler spec
+    with event_model.Filler({}) as filler:
+        filler('start', run_bundle.start_doc)
+        filler('descriptor', desc_bundle.descriptor_doc)
+        filler('descriptor', desc_bundle_baseline.descriptor_doc)
+        with pytest.raises(event_model.UndefinedAssetSpecification):
+            filler('resource', res_bundle.resource_doc)
 
     # Test exclude and include.
     with pytest.raises(ValueError):

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -232,7 +232,9 @@ def test_filler():
         filler('resource', res_bundle.resource_doc)
         filler('datum', datum_doc)
         event = copy.deepcopy(raw_event)
-        filler('event', event)
+        name, doc = filler('event', event)
+        assert name == 'event'
+        assert doc is event
         filler('stop', stop_doc)
         assert not filler._closed
     assert event['data']['image'].shape == (5, 5)

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -245,8 +245,12 @@ def test_filler():
         filler('start', run_bundle.start_doc)
         filler('descriptor', desc_bundle.descriptor_doc)
         filler('descriptor', desc_bundle_baseline.descriptor_doc)
+        filler('resource', res_bundle.resource_doc)
+        filler('datum', datum_doc)
+        event = copy.deepcopy(raw_event)
+        assert isinstance(event['data']['image'], str)
         with pytest.raises(event_model.UndefinedAssetSpecification):
-            filler('resource', res_bundle.resource_doc)
+            filler('event', event)
 
     # Test exclude and include.
     with pytest.raises(ValueError):


### PR DESCRIPTION
This is a working sketch that I live-coded at ISS for our "Minimum Viable Product" analysis pipeline demo.

The retry/backoff logic in `event` uses `time.sleep(...)`. We may want to refactor that so that it can be plugged into a sync, threaded, or async framework.