### PR TITLE
FIX: Accept {'filled': <boolean>} in event_page schema.

### DIFF
--- a/event_model/schemas/event.json
+++ b/event_model/schemas/event.json
@@ -11,7 +11,7 @@
         "filled": {
             "type": "object",
             "additionalProperties": {"type": ["boolean", "string"]},
-            "description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
+            "description": "Mapping each of the keys of externally-stored data to the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)"
         },
         "descriptor": {
             "type": "string",

--- a/event_model/schemas/event_page.json
+++ b/event_model/schemas/event_page.json
@@ -26,7 +26,7 @@
         },
         "filled": {
             "type": "dataframe_for_filled",
-            "description": "Mapping the keys of externally-stored data to a boolean indicating whether that data has yet been loaded"
+            "description": "Mapping each of the keys of externally-stored data to an array containing the boolean False, indicating that the data has not been loaded, or to foreign keys (moved here from 'data' when the data was loaded)"
         },
         "seq_num": {
             "type": "array",


### PR DESCRIPTION
Per page, I think a given data_key should either be entirely filled or entirely
unfilled.  So, an unfilled page would look like:

```py
{'data': {'image': [<datum1>, <datum2>]}, 'filled': {'image': False}}
```

and a filled page would look like:

```py
{'data': {'image': [<array1>, <array2>]}, 'filled': {'image': [datum_id1, datum_id2]}}
```

This would also be valid, as we still have some wiggle room at the schema
level around the contents of "filled".

```py
{'data': {'image': [<array1>, <array2>]}, 'filled': {'image': True}}
```

Currently the event_page schema *requires* filled to be a object of *arrays*
and thus does not accept ``'filled': {'image': False}`` because ``False`` is
not an array. This PR fixes that and updates the description of filled.