### PR TITLE
FIX: critical bug in sanitize_doc

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -843,48 +843,14 @@ def sanitize_doc(doc):
         The event-model document with numpy objects converted to built-in
         Python types.
     '''
-    sanitized_doc = doc.copy()
-    _apply_to_dict_recursively(doc, _sanitize_numpy)
-
-    return sanitized_doc
+    return json.loads(json.dumps(doc, cls=NumpyEncoder))
 
 
-def _sanitize_numpy(val):
-    '''Convert any numpy objects into built-in Python types.
-
-    Parameters
-    ----------
-    val : object
-        The potential numpy object to be converted.
-
-    Returns
-    -------
-    val : object
-        The input parameter, converted to a built-in Python type if it is a
-        numpy type.
-    '''
-    if isinstance(val, (numpy.generic, numpy.ndarray)):
-        if numpy.isscalar(val):
-            return val.item()
-        return val.tolist()
-    return val
-
-
-def _apply_to_dict_recursively(dictionary, func):
-    '''Recursively and apply a function to a dictionary of dictionaries.
-
-    Takes in a (potentially nested) dictionary and applies a function to each
-    value in the dictionary
-
-    Parameters
-    ----------
-    dictionary : dict
-        The (potentially nested) dictionary to be recursed.
-    func : function
-        A function to apply to each value in dictionary.
-    '''
-
-    for key, val in dictionary.items():
-        if hasattr(val, 'items'):
-            dictionary[key] = _apply_to_dict_recursively(val, func)
-        dictionary[key] = func(val)
+class NumpyEncoder(json.JSONEncoder):
+    # Credit: https://stackoverflow.com/a/47626762/1221924
+    def default(self, obj):
+        if isinstance(obj, (numpy.generic, numpy.ndarray)):
+            if numpy.isscalar(obj):
+                return obj.item()
+            return obj.tolist()
+        return json.JSONEncoder.default(self, obj)

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -181,7 +181,6 @@ def test_sanitize_doc():
 
     event_page = event_model.pack_event_page(event1, event2)
     bulk_events = {'primary': [event1, event2], 'baseline': [event3]}
-    pages = event_model.bulk_events_to_event_pages(bulk_events)
     json.dumps(event_model.sanitize_doc(event_page))
     json.dumps(event_model.sanitize_doc(bulk_events))
     json.dumps(event_model.sanitize_doc(event1))

--- a/event_model/test_em.py
+++ b/event_model/test_em.py
@@ -1,4 +1,5 @@
 import copy
+import json
 import event_model
 import numpy
 import pytest
@@ -153,6 +154,37 @@ def test_bulk_events_to_event_page():
     bulk_events = {'primary': [event1, event2], 'baseline': [event3]}
     pages = event_model.bulk_events_to_event_pages(bulk_events)
     assert tuple(pages) == (primary_event_page, baseline_event_page)
+
+
+def test_sanitize_doc():
+    run_bundle = event_model.compose_run()
+    desc_bundle = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'},
+                   'image': {'shape': [512, 512], 'dtype': 'number',
+                             'source': '...', 'external': 'FILESTORE:'}},
+        name='primary')
+    desc_bundle_baseline = run_bundle.compose_descriptor(
+        data_keys={'motor': {'shape': [], 'dtype': 'number', 'source': '...'}},
+        name='baseline')
+    event1 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': numpy.ones((512, 512))},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': True},
+        seq_num=1)
+    event2 = desc_bundle.compose_event(
+        data={'motor': 0, 'image': numpy.ones((512, 512))},
+        timestamps={'motor': 0, 'image': 0}, filled={'image': True},
+        seq_num=2)
+    event3 = desc_bundle_baseline.compose_event(
+        data={'motor': 0},
+        timestamps={'motor': 0},
+        seq_num=1)
+
+    event_page = event_model.pack_event_page(event1, event2)
+    bulk_events = {'primary': [event1, event2], 'baseline': [event3]}
+    pages = event_model.bulk_events_to_event_pages(bulk_events)
+    json.dumps(event_model.sanitize_doc(event_page))
+    json.dumps(event_model.sanitize_doc(bulk_events))
+    json.dumps(event_model.sanitize_doc(event1))
 
 
 def test_bulk_datum_to_datum_page():


### PR DESCRIPTION
- sanitize_doc modified the *input* and returned an unmodified copy
- sanitize_doc did not recurse into bulk_events

This implements a much simpler approach that uses the json serializer to
perform the recursion.