### PR TITLE
ENH: Stash datum_id on exception.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -307,9 +307,11 @@ class Filler(DocumentRouter):
                 try:
                     datum_doc = self._datum_cache[datum_id]
                 except KeyError as err:
-                    raise UnresolvableForeignKeyError(
+                    err_with_key = UnresolvableForeignKeyError(
                         f"Event with uid {doc['uid']} refers to unknown Datum "
-                        f"datum_id {datum_id}") from err
+                        f"datum_id {datum_id}")
+                    err_with_key.key = datum_id
+                    raise err_with_key from err
                 resource_uid = datum_doc['resource']
                 # Look up the cached Resource.
                 try:


### PR DESCRIPTION
This allows slick usages like:

```py
try:
    filler('event', event_doc)
except UnresolvableForeignKeyError as err:
    datum_id = err.key
    # Fetch datum by datum_id....
    filler('datum', datum_doc)
    filler('event', event_doc)
```