### PR TITLE
use object_keys rather than object_name

### DIFF
--- a/docs/source/data-model.rst
+++ b/docs/source/data-model.rst
@@ -116,7 +116,7 @@ Minimal nontrivial valid example:
                                    'source': 'PV:...'}},
     'hints': {},
     'name': 'primary',
-    'object_names': {},
+    'object_keys': {},
     'run_start': '10bf6945-4afd-43ca-af36-6ad8f3540bcd',  # foreign key
     'time': 1550070954.276659,
     'uid': 'd08d2ada-5f4e-495b-8e73-ff36186e7183'}

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -605,14 +605,14 @@ def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
 
 def compose_descriptor(*, start, streams, event_counter,
                        name, data_keys, uid=None, time=None,
-                       object_names=None, configuration=None, hints=None,
+                       object_keys=None, configuration=None, hints=None,
                        validate=True):
     if uid is None:
         uid = str(uuid.uuid4())
     if time is None:
         time = ttime.time()
-    if object_names is None:
-        object_names = {}
+    if object_keys is None:
+        object_keys = {}
     if configuration is None:
         configuration = {}
     if hints is None:
@@ -622,7 +622,7 @@ def compose_descriptor(*, start, streams, event_counter,
            'run_start': start['uid'],
            'name': name,
            'data_keys': data_keys,
-           'object_names': object_names,
+           'object_keys': object_keys,
            'hints': hints,
            'configuration': configuration}
     if validate:

--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -571,8 +571,10 @@ def compose_event_page(*, descriptor, event_counter, data, timestamps, seq_num,
     return doc
 
 
-def compose_event(*, descriptor, event_counter, data, timestamps, seq_num,
+def compose_event(*, descriptor, event_counter, data, timestamps, seq_num=None,
                   filled=None, uid=None, time=None, validate=True):
+    if seq_num is None:
+        seq_num = event_counter[descriptor['name']]
     if uid is None:
         uid = str(uuid.uuid4())
     if time is None:

--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -95,6 +95,10 @@
             "hints": {
                 "$ref": "#/definitions/object_hints"
             },
+            "object_keys": {
+                "type": "object",
+                "description": "Maps a Device/Signal name to the names of the entries it produces in data_keys."
+            },
             "name": {
                 "type": "string",
                 "description": "A human-friendly name for this data stream, such as 'primary' or 'baseline'."


### PR DESCRIPTION
It seems the name ``object_keys`` is used in bluesky not ``object_name``