### PR TITLE
DOC: release notes for 1.8.2, not 1.8.1 (abandoned)

### DIFF
--- a/docs/source/release-history.rst
+++ b/docs/source/release-history.rst
@@ -2,7 +2,7 @@
 Release History
 ***************
 
-v1.8.1 (2019-03-08)
+v1.8.2 (2019-03-08)
 ===================
 
 Fix setup.py meta-data to include ``python_requires``.  This prevents


### PR DESCRIPTION
We didn't push 1.8.1 to PyPI.