### PR TITLE
FIX: Add 'configuration' to EventDescriptor schema.

### DIFF
--- a/event_model/schemas/event_descriptor.json
+++ b/event_model/schemas/event_descriptor.json
@@ -68,6 +68,26 @@
                         }
                     }
                 }
+            },
+            "configuration": {
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "type": "object",
+                        "description": "The actual measurement data"
+                    },
+                    "timestamps": {
+                        "type": "object",
+                        "description": "The timestamps of the individual measurement data"
+                    },
+                    "data_keys": {
+                        "additionalProperties": {
+                            "$ref": "#/definitions/data_key"
+                        },
+                        "type": "object",
+                        "description": "This describes the data stored alongside it in this configuration object."
+                    }
+                }
             }
         },
         "properties": {
@@ -76,7 +96,7 @@
                     "$ref": "#/definitions/data_key"
                 },
                 "type": "object",
-                "description": "The describes the data to be in the event Documents",
+                "description": "This describes the data in the Event Documents.",
                 "title": "data_keys"
             },
             "uid": {
@@ -102,6 +122,13 @@
             "name": {
                 "type": "string",
                 "description": "A human-friendly name for this data stream, such as 'primary' or 'baseline'."
+            },
+            "configuration": {
+                "additionalProperties": {
+                    "$ref": "#/definitions/configuration"
+                },
+                "type": "object",
+                "description": "Readings of configurational fields necessary for interpreting data in the Events."
             }
         },
         "patternProperties": {


### PR DESCRIPTION
This PR adds specific validation for the "configuration" field. Up till now it
was treated as an arbitrary, user-provided field, accepted by the validators
but not specifically checked.

If I recall correctly, when we first added the concept of `read_configuration()`
to ophyd and bluesky, we intentionally did not immediately add "configuration"
to the schema in order to give us room to back out / change it. But at this
point adding it to the schema is long overdue.

Closes #57

h/t @ronpandolfi