### PR TITLE
FIX/TST: Typo made 'num_events' always empty.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -677,7 +677,8 @@ def compose_run(*, uid=None, time=None, metadata=None, validate=True):
         jsonschema.validate(doc, schemas[DocumentNames.start])
     return ComposeRunBundle(
         doc,
-        partial(compose_descriptor, start=doc, streams=streams, event_counter={}),
+        partial(compose_descriptor, start=doc, streams=streams,
+                event_counter=event_counter),
         partial(compose_resource, start=doc),
         partial(compose_stop, start=doc, event_counter=event_counter,
                 poison_pill=poison_pill))

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -55,7 +55,8 @@ def test_compose_run():
         timestamps={'motor': 0, 'image': 0}, filled={'image': False})
     assert 'descriptor' in event_doc
     assert event_doc['seq_num'] == 1
-    compose_stop()
+    stop_doc = compose_stop()
+    assert 'primary' in stop_doc['num_events']
 
 
 def test_round_trip_pagination():


### PR DESCRIPTION
h/t @CJ-Wright for noticing this bug.