### PR TITLE
FIX: Fix unpack_datum_page when datum_kwargs is empty.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -957,9 +957,10 @@ def unpack_datum_page(datum_page):
     """
     resource = datum_page['resource']
     datum_kwarg_list = _transpose_dict_of_lists(datum_page['datum_kwargs'])
-    for datum_id, datum_kwargs in zip(
+    for datum_id, datum_kwargs in itertools.zip_longest(
             datum_page['datum_id'],
-            datum_kwarg_list):
+            datum_kwarg_list,
+            fillvalue={}):
         datum = {'datum_id': datum_id, 'datum_kwargs': datum_kwargs,
                  'resource': resource}
         yield datum

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -135,6 +135,29 @@ def test_round_trip_pagination():
         event_model.pack_datum_page(*expected)))
     assert actual == expected
 
+    # Check edge case where datum_kwargs are empty.
+    datum_doc1 = res_bundle.compose_datum(datum_kwargs={})
+    datum_doc2 = res_bundle.compose_datum(datum_kwargs={})
+    datum_doc3 = res_bundle.compose_datum(datum_kwargs={})
+
+    # Round trip one datum -> datum_page -> datum.
+    expected = datum_doc1
+    actual, = event_model.unpack_datum_page(
+        event_model.pack_datum_page(expected))
+    assert actual == expected
+
+    # Round trip two datum -> datum_page -> datum.
+    expected = [datum_doc1, datum_doc2]
+    actual = list(event_model.unpack_datum_page(
+        event_model.pack_datum_page(*expected)))
+    assert actual == expected
+
+    # Round trip three datum -> datum_page -> datum.
+    expected = [datum_doc1, datum_doc2, datum_doc3]
+    actual = list(event_model.unpack_datum_page(
+        event_model.pack_datum_page(*expected)))
+    assert actual == expected
+
 
 def test_bulk_events_to_event_page(tmp_path):
     run_bundle = event_model.compose_run()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

When ``datum_kwargs`` is empty, ``unpack_datum_page`` returned an empty
list. This issue is that ``zip_longest``  should have been used where
``zip`` was used.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


~Needs test before merging!~ Unit tests added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->