### PR TITLE
FIX: Fill EventPage in as we fill Event in place.

### DIFF
--- a/event_model/__init__.py
+++ b/event_model/__init__.py
@@ -462,7 +462,11 @@ class Filler(DocumentRouter):
 
         for event_doc in unpack_event_page(doc):
             filled_events.append(event(event_doc))
-        return pack_event_page(*filled_events)
+        new_event_page = pack_event_page(*filled_events)
+        # Modify original doc in place, as we do with 'event'.
+        doc['data'] = new_event_page['data']
+        doc['filled'] = new_event_page['filled']
+        return doc
 
     def event(self, doc):
         for key, is_filled in doc['filled'].items():
@@ -526,6 +530,7 @@ class Filler(DocumentRouter):
                     ttime.sleep(interval)
                     try:
                         actual_data = handler(**datum_doc['datum_kwargs'])
+                        # Here we are intentionally modifying doc in place.
                         doc['data'][key] = actual_data
                         doc['filled'][key] = datum_id
                     except IOError as error_:

--- a/event_model/tests/test_em.py
+++ b/event_model/tests/test_em.py
@@ -310,7 +310,7 @@ def test_filler(tmp_path):
     filler.close()
     assert filler._closed
 
-    # Test context manager
+    # Test context manager with Event.
     with event_model.Filler(reg) as filler:
         filler('start', run_bundle.start_doc)
         filler('descriptor', desc_bundle.descriptor_doc)
@@ -324,6 +324,22 @@ def test_filler(tmp_path):
         filler('stop', stop_doc)
         assert not filler._closed
     assert event['data']['image'].shape == (5, 5)
+    assert filler._closed
+
+    # Test context manager with EventPage.
+    with event_model.Filler(reg) as filler:
+        filler('start', run_bundle.start_doc)
+        filler('descriptor', desc_bundle.descriptor_doc)
+        filler('descriptor', desc_bundle_baseline.descriptor_doc)
+        filler('resource', res_bundle.resource_doc)
+        filler('datum', datum_doc)
+        event_page = event_model.pack_event_page(copy.deepcopy(raw_event))
+        name, doc = filler('event_page', event_page)
+        assert name == 'event_page'
+        assert doc is event_page
+        filler('stop', stop_doc)
+        assert not filler._closed
+    assert event_page['data']['image'][0].shape == (5, 5)
     assert filler._closed
 
     # Test undefined handler spec


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

We modify Event documents in place when we will fill. This PR makes the
behavior for EventPages consistent.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


~Needs tests.~ Unit tests added.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!--
-->